### PR TITLE
Use log for logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,8 @@ name = "tun2proxy"
 version = "0.1.1"
 
 [dependencies]
-chrono = "0.4"
 clap = "3.2"
 mio = { version = "0.8", features = ["os-poll", "net", "os-ext"] }
 smoltcp = { version = "0.8", features = ["std"] }
+log = "0.4"
+env_logger = "0.9"

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,10 +5,12 @@ mod virtdevice;
 
 use crate::http::HttpManager;
 use crate::tun2proxy::TunToProxy;
+use env_logger::Env;
 use socks5::*;
 use std::net::ToSocketAddrs;
 
 fn main() {
+    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
     let matches = clap::App::new(env!("CARGO_PKG_NAME"))
         .version(env!("CARGO_PKG_VERSION"))
         .about("Tunnel interface to proxy.")

--- a/src/tun2proxy.rs
+++ b/src/tun2proxy.rs
@@ -1,4 +1,5 @@
 use crate::virtdevice::VirtualTunDevice;
+use log::{error, info};
 use mio::event::Event;
 use mio::net::TcpStream;
 use mio::unix::SourceFd;
@@ -255,7 +256,7 @@ impl<'a> TunToProxy<'a> {
             .registry()
             .deregister(&mut connection_state.mio_stream)
             .unwrap();
-        println!("[{:?}] CLOSE {}", chrono::offset::Local::now(), connection);
+        info!("CLOSE {}", connection);
     }
 
     fn get_connection_manager(&self, connection: &Connection) -> Option<&dyn ConnectionManager> {
@@ -268,7 +269,7 @@ impl<'a> TunToProxy<'a> {
     }
 
     fn print_error(error: ProxyError) {
-        println!("Error: {}", error.message());
+        error!("{}", error.message());
     }
 
     fn tunsocket_read_and_forward(&mut self, connection: &Connection) {
@@ -355,11 +356,7 @@ impl<'a> TunToProxy<'a> {
 
                             self.connections.insert(connection, state);
 
-                            println!(
-                                "[{:?}] CONNECT {}",
-                                chrono::offset::Local::now(),
-                                connection
-                            );
+                            info!("CONNECT {}", connection,);
                             break;
                         }
                     }


### PR DESCRIPTION
Use log crate for generating info and error output.

In order to maintain same verbosity, set default log level to 'info'. Can be overridden by setting the `RUST_LOG` env variable, e.g. `RUST_LOG=error`.