### PR TITLE
Fix #20 - older rust versions

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -8,7 +8,7 @@ use std::ffi::OsStr;
 use std::io::BufRead;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-use std::os::fd::RawFd;
+use std::os::unix::io::RawFd;
 
 use std::process::{Command, Output};
 


### PR DESCRIPTION
There was regression of https://github.com/blechschmidt/tun2proxy/commit/b8a08871d05bf4f2107fc4f5d4f1fe05c9e7cd06