### PR TITLE
dynamic port

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ dotenvy = "0.15"
 env_logger = "0.10"
 fork = "0.1"
 hashlink = "0.8"
+lazy_static = "1.4"
 libc = "0.2"
 log = "0.4"
 mio = { version = "0.8", features = ["os-poll", "net", "os-ext"] }


### PR DESCRIPTION
Since [mio_pipe](https://docs.rs/mio-pipe/latest/mio_pipe/index.html) is not part of mio and not support windows, I think use dynamic port is a better selection.