### PR TITLE
Initial support for digest auth scheme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ prctl = "1.0"
 smoltcp = { version = "0.9.1", git = "https://github.com/smoltcp-rs/smoltcp", features = ["std", "phy-tuntap_interface"] }
 thiserror = "1.0"
 url = "2.3"
+digest_auth = "0.3.1"
+httparse = "1.8.0"
+unicase = "2.6.0"
 
 [target.'cfg(target_os="android")'.dependencies]
 android_logger = "0.13"

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,6 +48,12 @@ pub enum Error {
 
     #[error("std::num::ParseIntError {0:?}")]
     IntParseError(#[from] std::num::ParseIntError),
+
+    #[error("httparse::Error {0}")]
+    HttpError(#[from] httparse::Error),
+
+    #[error("digest_auth::Error {0}")]
+    DigestAuthError(#[from] digest_auth::Error),
 }
 
 impl From<&str> for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,15 +110,15 @@ impl Options {
 
 #[derive(Default, Clone, Debug)]
 pub struct Credentials {
-    pub(crate) username: Vec<u8>,
-    pub(crate) password: Vec<u8>,
+    pub(crate) username: String,
+    pub(crate) password: String,
 }
 
 impl Credentials {
     pub fn new(username: &str, password: &str) -> Self {
         Self {
-            username: username.as_bytes().to_vec(),
-            password: password.as_bytes().to_vec(),
+            username: String::from(username),
+            password: String::from(password),
         }
     }
 }

--- a/src/socks.rs
+++ b/src/socks.rs
@@ -156,10 +156,10 @@ impl SocksConnection {
                 }
                 self.server_outbuf.extend(ip_vec);
                 if let Some(credentials) = credentials {
-                    self.server_outbuf.extend(&credentials.username);
+                    self.server_outbuf.extend(credentials.username.as_bytes());
                     if !credentials.password.is_empty() {
                         self.server_outbuf.push_back(b':');
-                        self.server_outbuf.extend(&credentials.password);
+                        self.server_outbuf.extend(credentials.password.as_bytes());
                     }
                 }
                 self.server_outbuf.push_back(0);
@@ -250,10 +250,10 @@ impl SocksConnection {
         let credentials = self.credentials.as_ref().unwrap_or(&tmp);
         self.server_outbuf
             .extend(&[1u8, credentials.username.len() as u8]);
-        self.server_outbuf.extend(&credentials.username);
+        self.server_outbuf.extend(credentials.username.as_bytes());
         self.server_outbuf
             .extend(&[credentials.password.len() as u8]);
-        self.server_outbuf.extend(&credentials.password);
+        self.server_outbuf.extend(credentials.password.as_bytes());
         self.state = SocksState::ReceiveAuthResponse;
         self.state_change()
     }
@@ -423,6 +423,10 @@ impl TcpProxy for SocksConnection {
                 OutgoingDirection::ToClient => !self.client_outbuf.is_empty(),
             },
         }
+    }
+
+    fn reset_connection(&self) -> bool {
+        false
     }
 }
 


### PR DESCRIPTION
Issue #43

Actually this works after the second request (when it gets the proxy challenge parameters). This must be because I made some mistake while restarting the connection. The workflow should be something like this (at the start of the program): 

1. tun2proxy makes the request using the basic authentication scheme 
2. The server returns a 407 error with the `Proxy-Authenticate` tag and the challenge digest parameters. 
3. If the server specifies `Connection: close` or does not specify any header nor `Content-Length` or `Transfer-Encoding` then the connection is closed and restarted. Otherwise, it determines the size of the current HTTP frame and jumps to it. 
3. tun2proxy now sends the request using the authentication digest with the response values to the challenge.
4. For next request tun2proxy holds the old `nonce` param and use it to authenticate the response until the proxy requests by a new one, so, reset the connection with the proxy isn't longer needed 