### PR TITLE
Add support for unprivileged namespaces on linux

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,7 @@ env:
 jobs:
   build_n_test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
@@ -16,11 +17,23 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+
     - name: rustfmt
+      if: ${{ !cancelled() }}
       run: cargo fmt --all -- --check
+
     - name: check
+      if: ${{ !cancelled() }}
       run: cargo check --verbose
+
     - name: clippy
+      if: ${{ !cancelled() }}
       run: cargo clippy --all-targets --all-features -- -D warnings
+
     - name: Build
+      if: ${{ !cancelled() }}
       run: cargo build --verbose --tests --all-features
+
+    - name: Abort on error
+      if: ${{ failure() }}
+      run: echo "Some of jobs failed" && false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,11 @@ udp-stream = { version = "0.0", default-features = false }
 unicase = "2.7"
 url = "2.5"
 
+[target.'cfg(target_os="linux")'.dependencies]
+serde = { version = "1", features = [ "derive" ] }
+bincode = "1"
+nix = { version = "0", default-features = false, features = ["fs", "socket", "uio"] }
+
 [target.'cfg(target_os="android")'.dependencies]
 android_logger = "0.13"
 jni = { version = "0.21", default-features = false }

--- a/README.md
+++ b/README.md
@@ -114,22 +114,32 @@ sudo ip link del tun0
 ```
 Tunnel interface to proxy.
 
-Usage: tun2proxy [OPTIONS] --proxy <URL>
+Usage: tun2proxy [OPTIONS] --proxy <URL> [ADMIN_COMMAND]...
+
+Arguments:
+  [ADMIN_COMMAND]...  Specify a command to run with root-like capabilities in the new namespace when using `--unshare`.
+                      This could be useful to start additional daemons, e.g. `openvpn` instance
 
 Options:
-  -p, --proxy <URL>        Proxy URL in the form proto://[username[:password]@]host:port, where proto is one of socks4,
-                           socks5, http. For example: socks5://myname:password@127.0.0.1:1080
-  -t, --tun <name>         Name of the tun interface [default: tun0]
-      --tun-fd <fd>        File descriptor of the tun interface
-  -6, --ipv6-enabled       IPv6 enabled
-  -s, --setup              Routing and system setup, which decides whether to setup the routing and system configuration,
-                           this option requires root privileges
-  -d, --dns <strategy>     DNS handling strategy [default: direct] [possible values: virtual, over-tcp, direct]
-      --dns-addr <IP>      DNS resolver address [default: 8.8.8.8]
-  -b, --bypass <IP>        IPs used in routing setup which should bypass the tunnel
-  -v, --verbosity <level>  Verbosity level [default: info] [possible values: off, error, warn, info, debug, trace]
-  -h, --help               Print help
-  -V, --version            Print version
+  -p, --proxy <URL>            Proxy URL in the form proto://[username[:password]@]host:port, where proto is one of
+                               socks4, socks5, http. For example: socks5://myname:password@127.0.0.1:1080
+  -t, --tun <name>             Name of the tun interface, such as tun0, utun4, etc. If this option is not provided, the
+                               OS will generate a random one
+      --tun-fd <fd>            File descriptor of the tun interface
+      --unshare                Create a tun interface in a newly created unprivileged namespace while maintaining proxy
+                               connectivity via the global network namespace
+  -6, --ipv6-enabled           IPv6 enabled
+  -s, --setup                  Routing and system setup, which decides whether to setup the routing and system
+                               configuration. This option is only available on Linux and requires root-like privileges.
+                               See `capabilities(7)`
+  -d, --dns <strategy>         DNS handling strategy [default: direct] [possible values: virtual, over-tcp, direct]
+      --dns-addr <IP>          DNS resolver address [default: 8.8.8.8]
+  -b, --bypass <IP>            IPs used in routing setup which should bypass the tunnel
+      --tcp-timeout <seconds>  TCP timeout in seconds [default: 600]
+      --udp-timeout <seconds>  UDP timeout in seconds [default: 10]
+  -v, --verbosity <level>      Verbosity level [default: info] [possible values: off, error, warn, info, debug, trace]
+  -h, --help                   Print help
+  -V, --version                Print version
 ```
 Currently, tun2proxy supports HTTP, SOCKS4/SOCKS4a and SOCKS5. A proxy is supplied to the `--proxy` argument in the
 URL format. For example, an HTTP proxy at `1.2.3.4:3128` with a username of `john.doe` and a password of `secret` is

--- a/src/args.rs
+++ b/src/args.rs
@@ -249,6 +249,14 @@ impl std::fmt::Display for ArgProxy {
 
 impl ArgProxy {
     pub fn from_url(s: &str) -> Result<ArgProxy> {
+        if s == "none" {
+            return Ok(ArgProxy {
+                proxy_type: ProxyType::None,
+                addr: "0.0.0.0:0".parse().unwrap(),
+                credentials: None,
+            });
+        }
+
         let e = format!("`{s}` is not a valid proxy URL");
         let url = url::Url::parse(s).map_err(|_| Error::from(&e))?;
         let e = format!("`{s}` does not contain a host");
@@ -299,6 +307,7 @@ pub enum ProxyType {
     Socks4,
     #[default]
     Socks5,
+    None,
 }
 
 impl std::fmt::Display for ProxyType {
@@ -307,6 +316,7 @@ impl std::fmt::Display for ProxyType {
             ProxyType::Socks4 => write!(f, "socks4"),
             ProxyType::Socks5 => write!(f, "socks5"),
             ProxyType::Http => write!(f, "http"),
+            ProxyType::None => write!(f, "none"),
         }
     }
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -45,6 +45,10 @@ pub struct Args {
     #[arg(long, value_name = "seconds", default_value = "600")]
     pub tcp_timeout: u64,
 
+    /// UDP timeout in seconds
+    #[arg(long, value_name = "seconds", default_value = "10")]
+    pub udp_timeout: u64,
+
     /// Verbosity level
     #[arg(short, long, value_name = "level", value_enum, default_value = "info")]
     pub verbosity: ArgVerbosity,
@@ -62,6 +66,7 @@ impl Default for Args {
             dns_addr: "8.8.8.8".parse().unwrap(),
             bypass: vec![],
             tcp_timeout: 600,
+            udp_timeout: 10,
             verbosity: ArgVerbosity::Info,
         }
     }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -13,8 +13,17 @@ async fn main() -> Result<(), BoxError> {
     let join_handle = tokio::spawn({
         let shutdown_token = shutdown_token.clone();
         async move {
-            if let Err(err) = tun2proxy::desktop_run_async(args, shutdown_token).await {
-                log::error!("main loop error: {}", err);
+            if args.unshare && args.socket_transfer_fd.is_none() {
+                #[cfg(target_os = "linux")]
+                if let Err(err) = namespace_proxy_main(args, shutdown_token).await {
+                    log::error!("namespace proxy error: {}", err);
+                }
+                #[cfg(not(target_os = "linux"))]
+                log::error!("Your platform doesn't support unprivileged namespaces");
+            } else {
+                if let Err(err) = tun2proxy::desktop_run_async(args, shutdown_token).await {
+                    log::error!("main loop error: {}", err);
+                }
             }
         }
     });
@@ -30,4 +39,49 @@ async fn main() -> Result<(), BoxError> {
     }
 
     Ok(())
+}
+
+#[cfg(target_os = "linux")]
+async fn namespace_proxy_main(
+    _args: Args,
+    _shutdown_token: tokio_util::sync::CancellationToken,
+) -> Result<std::process::ExitStatus, tun2proxy::Error> {
+    use std::os::fd::AsRawFd;
+
+    let (socket, remote_fd) = tun2proxy::socket_transfer::create_transfer_socket_pair().await?;
+
+    let child = tokio::process::Command::new("unshare")
+        .args("--user --map-current-user --net --mount --keep-caps --kill-child --fork".split(' '))
+        .arg(std::env::current_exe()?)
+        .arg("--socket-transfer-fd")
+        .arg(remote_fd.as_raw_fd().to_string())
+        .args(std::env::args().skip(1))
+        .kill_on_drop(true)
+        .spawn();
+
+    let mut child = match child {
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            log::error!("`unshare(1)` executable wasn't located in PATH.");
+            log::error!("Consider installing linux utils package: `apt install util-linux`");
+            log::error!("Or similar for your distribution.");
+            return Err(err.into());
+        }
+        child => child?,
+    };
+
+    log::info!("The tun proxy is running in unprivileged mode. See `namespaces(7)`.");
+    log::info!("");
+    log::info!("If you need to run a process that relies on root-like capabilities (e.g. `openvpn`)");
+    log::info!("Use `tun2proxy --unshare --setup [...] -- openvpn --config [...]`");
+    log::info!("");
+    log::info!("To run a new process in the created namespace (e.g. a flatpak app)");
+    log::info!(
+        "Use `nsenter --preserve-credentials --user --net --mount  --target {} /bin/sh`",
+        child.id().unwrap_or(0)
+    );
+    log::info!("");
+
+    tokio::spawn(async move { tun2proxy::socket_transfer::process_socket_requests(&socket).await });
+
+    Ok(child.wait().await?)
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -20,10 +20,8 @@ async fn main() -> Result<(), BoxError> {
                 }
                 #[cfg(not(target_os = "linux"))]
                 log::error!("Your platform doesn't support unprivileged namespaces");
-            } else {
-                if let Err(err) = tun2proxy::desktop_run_async(args, shutdown_token).await {
-                    log::error!("main loop error: {}", err);
-                }
+            } else if let Err(err) = tun2proxy::desktop_run_async(args, shutdown_token).await {
+                log::error!("main loop error: {}", err);
             }
         }
     });

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,10 @@ pub enum Error {
     #[error(transparent)]
     Io(#[from] std::io::Error),
 
+    #[cfg(target_os = "linux")]
+    #[error("nix::errno::Errno {0:?}")]
+    NixErrno(#[from] nix::errno::Errno),
+
     #[error("TryFromIntError {0:?}")]
     TryFromInt(#[from] std::num::TryFromIntError),
 
@@ -39,6 +43,10 @@ pub enum Error {
 
     #[error("std::num::ParseIntError {0:?}")]
     IntParseError(#[from] std::num::ParseIntError),
+
+    #[cfg(target_os = "linux")]
+    #[error("bincode::Error {0:?}")]
+    BincodeError(#[from] bincode::Error),
 }
 
 impl From<&str> for Error {

--- a/src/http.rs
+++ b/src/http.rs
@@ -423,10 +423,6 @@ impl ProxyHandlerManager for HttpManager {
             HttpConnection::new(self.server, info, domain_name, self.credentials.clone(), self.digest_state.clone()).await?,
         )))
     }
-
-    fn get_server_addr(&self) -> SocketAddr {
-        self.server
-    }
 }
 
 impl HttpManager {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,7 +214,7 @@ where
         ProxyType::Socks5 => Arc::new(SocksProxyManager::new(server_addr, V5, key)) as Arc<dyn ProxyHandlerManager>,
         ProxyType::Socks4 => Arc::new(SocksProxyManager::new(server_addr, V4, key)) as Arc<dyn ProxyHandlerManager>,
         ProxyType::Http => Arc::new(HttpManager::new(server_addr, key)) as Arc<dyn ProxyHandlerManager>,
-        ProxyType::None => Arc::new(NoProxyManager::new(server_addr)) as Arc<dyn ProxyHandlerManager>,
+        ProxyType::None => Arc::new(NoProxyManager::new()) as Arc<dyn ProxyHandlerManager>,
     };
 
     let mut ipstack_config = ipstack::IpStackConfig::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,6 @@ mod virtual_dns;
 const DNS_PORT: u16 = 53;
 
 const MAX_SESSIONS: u64 = 200;
-const UDP_TIMEOUT_SEC: u64 = 10; // 10 seconds
 
 static TASK_COUNT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 use std::sync::atomic::Ordering::Relaxed;
@@ -87,7 +86,7 @@ where
     let mut ipstack_config = ipstack::IpStackConfig::default();
     ipstack_config.mtu(mtu);
     ipstack_config.tcp_timeout(std::time::Duration::from_secs(args.tcp_timeout));
-    ipstack_config.udp_timeout(std::time::Duration::from_secs(UDP_TIMEOUT_SEC));
+    ipstack_config.udp_timeout(std::time::Duration::from_secs(args.udp_timeout));
 
     let mut ip_stack = ipstack::IpStack::new(ipstack_config, device);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use crate::{
     directions::{IncomingDataEvent, IncomingDirection, OutgoingDirection},
     http::HttpManager,
+    no_proxy::NoProxyManager,
     session_info::{IpProtocol, SessionInfo},
     virtual_dns::VirtualDns,
 };
@@ -42,6 +43,7 @@ mod dump_logger;
 mod error;
 mod http;
 mod mobile_api;
+mod no_proxy;
 mod proxy_handler;
 mod session_info;
 mod socks;
@@ -81,6 +83,7 @@ where
         ProxyType::Socks5 => Arc::new(SocksProxyManager::new(server_addr, V5, key)) as Arc<dyn ProxyHandlerManager>,
         ProxyType::Socks4 => Arc::new(SocksProxyManager::new(server_addr, V4, key)) as Arc<dyn ProxyHandlerManager>,
         ProxyType::Http => Arc::new(HttpManager::new(server_addr, key)) as Arc<dyn ProxyHandlerManager>,
+        ProxyType::None => Arc::new(NoProxyManager::new(server_addr)) as Arc<dyn ProxyHandlerManager>,
     };
 
     let mut ipstack_config = ipstack::IpStackConfig::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,6 +405,8 @@ async fn handle_udp_associate_session(
 
     log::info!("Beginning {}", session_info);
 
+    // `_server` is meaningful here, it must be alive all the time
+    // to ensure that UDP transmission will not be interrupted accidentally.
     let (_server, udp_addr) = match udp_addr {
         Some(udp_addr) => (None, udp_addr),
         None => {
@@ -567,6 +569,9 @@ async fn handle_dns_over_tcp_session(
     Ok(())
 }
 
+/// This function is used to handle the business logic of tun2proxy and SOCKS5 server.
+/// When handling UDP proxy, the return value UDP associate IP address is the result of this business logic.
+/// However, when handling TCP business logic, the return value Ok(None) is meaningless, just indicating that the operation was successful.
 async fn handle_proxy_session(server: &mut TcpStream, proxy_handler: Arc<Mutex<dyn ProxyHandler>>) -> crate::Result<Option<SocketAddr>> {
     let mut launched = false;
     let mut proxy_handler = proxy_handler.lock().await;

--- a/src/no_proxy.rs
+++ b/src/no_proxy.rs
@@ -16,6 +16,10 @@ struct NoProxyHandler {
 
 #[async_trait::async_trait]
 impl ProxyHandler for NoProxyHandler {
+    fn get_server_addr(&self) -> SocketAddr {
+        self.info.dst
+    }
+
     fn get_session_info(&self) -> SessionInfo {
         self.info
     }

--- a/src/no_proxy.rs
+++ b/src/no_proxy.rs
@@ -1,0 +1,109 @@
+use crate::{
+    directions::{IncomingDataEvent, IncomingDirection, OutgoingDataEvent, OutgoingDirection},
+    proxy_handler::{ProxyHandler, ProxyHandlerManager},
+    session_info::SessionInfo,
+};
+use std::{collections::VecDeque, net::SocketAddr, sync::Arc};
+use tokio::sync::Mutex;
+
+struct NoProxyHandler {
+    info: SessionInfo,
+    domain_name: Option<String>,
+    client_outbuf: VecDeque<u8>,
+    server_outbuf: VecDeque<u8>,
+    udp_associate: bool,
+}
+
+#[async_trait::async_trait]
+impl ProxyHandler for NoProxyHandler {
+    fn get_session_info(&self) -> SessionInfo {
+        self.info
+    }
+
+    fn get_domain_name(&self) -> Option<String> {
+        self.domain_name.clone()
+    }
+
+    async fn push_data(&mut self, event: IncomingDataEvent<'_>) -> std::io::Result<()> {
+        let IncomingDataEvent { direction, buffer } = event;
+        match direction {
+            IncomingDirection::FromServer => {
+                self.client_outbuf.extend(buffer.iter());
+            }
+            IncomingDirection::FromClient => {
+                self.server_outbuf.extend(buffer.iter());
+            }
+        }
+        Ok(())
+    }
+
+    fn consume_data(&mut self, dir: OutgoingDirection, size: usize) {
+        let buffer = match dir {
+            OutgoingDirection::ToServer => &mut self.server_outbuf,
+            OutgoingDirection::ToClient => &mut self.client_outbuf,
+        };
+        buffer.drain(0..size);
+    }
+
+    fn peek_data(&mut self, dir: OutgoingDirection) -> OutgoingDataEvent {
+        let buffer = match dir {
+            OutgoingDirection::ToServer => &mut self.server_outbuf,
+            OutgoingDirection::ToClient => &mut self.client_outbuf,
+        };
+        OutgoingDataEvent {
+            direction: dir,
+            buffer: buffer.make_contiguous(),
+        }
+    }
+
+    fn connection_established(&self) -> bool {
+        true
+    }
+
+    fn data_len(&self, dir: OutgoingDirection) -> usize {
+        match dir {
+            OutgoingDirection::ToServer => self.server_outbuf.len(),
+            OutgoingDirection::ToClient => self.client_outbuf.len(),
+        }
+    }
+
+    fn reset_connection(&self) -> bool {
+        false
+    }
+
+    fn get_udp_associate(&self) -> Option<SocketAddr> {
+        self.udp_associate.then_some(self.info.dst)
+    }
+}
+
+pub(crate) struct NoProxyManager {
+    server: SocketAddr,
+}
+
+#[async_trait::async_trait]
+impl ProxyHandlerManager for NoProxyManager {
+    async fn new_proxy_handler(
+        &self,
+        info: SessionInfo,
+        domain_name: Option<String>,
+        udp_associate: bool,
+    ) -> std::io::Result<Arc<Mutex<dyn ProxyHandler>>> {
+        Ok(Arc::new(Mutex::new(NoProxyHandler {
+            info,
+            domain_name,
+            client_outbuf: VecDeque::default(),
+            server_outbuf: VecDeque::default(),
+            udp_associate,
+        })))
+    }
+
+    fn get_server_addr(&self) -> SocketAddr {
+        self.server
+    }
+}
+
+impl NoProxyManager {
+    pub(crate) fn new(server: SocketAddr) -> Self {
+        Self { server }
+    }
+}

--- a/src/no_proxy.rs
+++ b/src/no_proxy.rs
@@ -80,9 +80,7 @@ impl ProxyHandler for NoProxyHandler {
     }
 }
 
-pub(crate) struct NoProxyManager {
-    server: SocketAddr,
-}
+pub(crate) struct NoProxyManager;
 
 #[async_trait::async_trait]
 impl ProxyHandlerManager for NoProxyManager {
@@ -100,14 +98,10 @@ impl ProxyHandlerManager for NoProxyManager {
             udp_associate,
         })))
     }
-
-    fn get_server_addr(&self) -> SocketAddr {
-        self.server
-    }
 }
 
 impl NoProxyManager {
-    pub(crate) fn new(server: SocketAddr) -> Self {
-        Self { server }
+    pub(crate) fn new() -> Self {
+        Self
     }
 }

--- a/src/proxy_handler.rs
+++ b/src/proxy_handler.rs
@@ -7,6 +7,7 @@ use tokio::sync::Mutex;
 
 #[async_trait::async_trait]
 pub(crate) trait ProxyHandler: Send + Sync {
+    fn get_server_addr(&self) -> SocketAddr;
     fn get_session_info(&self) -> SessionInfo;
     fn get_domain_name(&self) -> Option<String>;
     async fn push_data(&mut self, event: IncomingDataEvent<'_>) -> std::io::Result<()>;

--- a/src/proxy_handler.rs
+++ b/src/proxy_handler.rs
@@ -27,5 +27,4 @@ pub(crate) trait ProxyHandlerManager: Send + Sync {
         domain_name: Option<String>,
         udp_associate: bool,
     ) -> std::io::Result<Arc<Mutex<dyn ProxyHandler>>>;
-    fn get_server_addr(&self) -> SocketAddr;
 }

--- a/src/socket_transfer.rs
+++ b/src/socket_transfer.rs
@@ -1,0 +1,230 @@
+#![cfg(target_os = "linux")]
+
+use crate::{error, SocketDomain, SocketProtocol};
+use nix::{
+    errno::Errno,
+    fcntl::{self, FdFlag},
+    sys::socket::{cmsg_space, getsockopt, recvmsg, sendmsg, sockopt, ControlMessage, ControlMessageOwned, MsgFlags, SockType},
+};
+use serde::{Deserialize, Serialize};
+use std::{
+    io::{ErrorKind, IoSlice, IoSliceMut, Result},
+    ops::DerefMut,
+    os::fd::{AsFd, AsRawFd, FromRawFd, IntoRawFd, OwnedFd, RawFd},
+};
+use tokio::net::{TcpSocket, UdpSocket, UnixDatagram};
+
+const REQUEST_BUFFER_SIZE: usize = 64;
+
+#[derive(Hash, Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+struct Request {
+    protocol: SocketProtocol,
+    domain: SocketDomain,
+    number: u32,
+}
+
+#[derive(Hash, Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+enum Response {
+    Ok,
+}
+
+/// Reconstruct socket from raw `fd`
+pub fn reconstruct_socket(fd: RawFd) -> Result<OwnedFd> {
+    // Check if `fd` is valid
+    let fd_flags = fcntl::fcntl(fd, fcntl::F_GETFD)?;
+
+    // `fd` is confirmed to be valid so it should be closed
+    let socket = unsafe { OwnedFd::from_raw_fd(fd) };
+
+    // Insert CLOEXEC flag to the `fd` to prevent further propagation across `execve(2)` calls
+    let mut fd_flags = FdFlag::from_bits(fd_flags).ok_or(ErrorKind::Unsupported)?;
+    if !fd_flags.contains(FdFlag::FD_CLOEXEC) {
+        fd_flags.insert(FdFlag::FD_CLOEXEC);
+        fcntl::fcntl(fd, fcntl::F_SETFD(fd_flags))?;
+    }
+
+    Ok(socket)
+}
+
+/// Reconstruct transfer socket from `fd`
+///
+/// Panics if called outside of tokio runtime
+pub fn reconstruct_transfer_socket(fd: OwnedFd) -> Result<UnixDatagram> {
+    // Check if socket of type DATAGRAM
+    let sock_type = getsockopt(&fd, sockopt::SockType)?;
+    if !matches!(sock_type, SockType::Datagram) {
+        return Err(ErrorKind::InvalidInput.into());
+    }
+
+    let std_socket: std::os::unix::net::UnixDatagram = fd.into();
+    std_socket.set_nonblocking(true)?;
+
+    // Fails if tokio context is absent
+    Ok(UnixDatagram::from_std(std_socket).unwrap())
+}
+
+/// Create pair of interconnected sockets one of which is set to stay open across `execve(2)` calls.
+pub async fn create_transfer_socket_pair() -> std::io::Result<(UnixDatagram, OwnedFd)> {
+    let (local, remote) = tokio::net::UnixDatagram::pair()?;
+
+    let remote_fd: OwnedFd = remote.into_std().unwrap().into();
+
+    // Get `remote_fd` flags
+    let fd_flags = fcntl::fcntl(remote_fd.as_raw_fd(), fcntl::F_GETFD)?;
+
+    // Remove CLOEXEC flag from the `remote_fd` to allow propagating across `execve(2)`
+    let mut fd_flags = FdFlag::from_bits(fd_flags).ok_or(ErrorKind::Unsupported)?;
+    fd_flags.remove(FdFlag::FD_CLOEXEC);
+    fcntl::fcntl(remote_fd.as_raw_fd(), fcntl::F_SETFD(fd_flags))?;
+
+    Ok((local, remote_fd))
+}
+
+pub trait TransferableSocket: Sized {
+    fn from_fd(fd: OwnedFd) -> Result<Self>;
+    fn domain() -> SocketProtocol;
+}
+
+impl TransferableSocket for TcpSocket {
+    fn from_fd(fd: OwnedFd) -> Result<Self> {
+        // Check if socket is of type STREAM
+        let sock_type = getsockopt(&fd, sockopt::SockType)?;
+        if !matches!(sock_type, SockType::Stream) {
+            return Err(ErrorKind::InvalidInput.into());
+        }
+
+        let std_stream: std::net::TcpStream = fd.into();
+        std_stream.set_nonblocking(true)?;
+
+        Ok(TcpSocket::from_std_stream(std_stream))
+    }
+
+    fn domain() -> SocketProtocol {
+        SocketProtocol::Tcp
+    }
+}
+
+impl TransferableSocket for UdpSocket {
+    /// Panics if called outside of tokio runtime
+    fn from_fd(fd: OwnedFd) -> Result<Self> {
+        // Check if socket is of type DATAGRAM
+        let sock_type = getsockopt(&fd, sockopt::SockType)?;
+        if !matches!(sock_type, SockType::Datagram) {
+            return Err(ErrorKind::InvalidInput.into());
+        }
+
+        let std_socket: std::net::UdpSocket = fd.into();
+        std_socket.set_nonblocking(true)?;
+
+        Ok(UdpSocket::try_from(std_socket).unwrap())
+    }
+
+    fn domain() -> SocketProtocol {
+        SocketProtocol::Udp
+    }
+}
+
+/// Send [`Request`] to `socket` and return received [`TransferableSocket`]s
+///
+/// Panics if called outside of tokio runtime
+pub async fn request_sockets<S, T>(mut socket: S, domain: SocketDomain, number: u32) -> error::Result<Vec<T>>
+where
+    S: DerefMut<Target = UnixDatagram>,
+    T: TransferableSocket,
+{
+    // Borrow socket as mut to prevent multiple simultaneous requests
+    let socket = socket.deref_mut();
+
+    // Send request
+    let request = bincode::serialize(&Request {
+        protocol: T::domain(),
+        domain,
+        number,
+    })?;
+
+    socket.send(&request[..]).await?;
+
+    // Receive response
+    loop {
+        socket.readable().await?;
+
+        let mut buf = [0_u8; REQUEST_BUFFER_SIZE];
+        let mut iov = [IoSliceMut::new(&mut buf[..])];
+        let mut cmsg = Vec::with_capacity(cmsg_space::<RawFd>() * number as usize);
+
+        let msg = recvmsg::<()>(socket.as_fd().as_raw_fd(), &mut iov, Some(&mut cmsg), MsgFlags::empty());
+
+        let msg = match msg {
+            Err(Errno::EAGAIN) => continue,
+            msg => msg?,
+        };
+
+        // Parse response
+        let response = &msg.iovs().next().unwrap()[..msg.bytes];
+        let response: Response = bincode::deserialize(response)?;
+        if !matches!(response, Response::Ok) {
+            return Err("Request for new sockets failed".into());
+        }
+
+        // Process received file descriptors
+        let mut sockets = Vec::<T>::with_capacity(number as usize);
+        for cmsg in msg.cmsgs() {
+            if let ControlMessageOwned::ScmRights(fds) = cmsg {
+                for fd in fds {
+                    if fd < 0 {
+                        return Err("Received socket is invalid".into());
+                    }
+
+                    let owned_fd = reconstruct_socket(fd)?;
+                    sockets.push(T::from_fd(owned_fd)?);
+                }
+            }
+        }
+
+        return Ok(sockets);
+    }
+}
+
+/// Process [`Request`]s received from `socket`
+///
+/// Panics if called outside of tokio runtime
+pub async fn process_socket_requests(socket: &UnixDatagram) -> error::Result<()> {
+    loop {
+        let mut buf = [0_u8; REQUEST_BUFFER_SIZE];
+
+        let len = socket.recv(&mut buf[..]).await?;
+
+        let request: Request = bincode::deserialize(&buf[..len])?;
+
+        let response = Response::Ok;
+        let buf = bincode::serialize(&response)?;
+
+        let mut owned_fd_buf: Vec<OwnedFd> = Vec::with_capacity(request.number as usize);
+        for _ in 0..request.number {
+            let fd = match request.protocol {
+                SocketProtocol::Tcp => match request.domain {
+                    SocketDomain::IpV4 => tokio::net::TcpSocket::new_v4(),
+                    SocketDomain::IpV6 => tokio::net::TcpSocket::new_v6(),
+                }
+                .map(|s| unsafe { OwnedFd::from_raw_fd(s.into_raw_fd()) }),
+                SocketProtocol::Udp => match request.domain {
+                    SocketDomain::IpV4 => tokio::net::UdpSocket::bind("0.0.0.0:0").await,
+                    SocketDomain::IpV6 => tokio::net::UdpSocket::bind("[::]:0").await,
+                }
+                .map(|s| s.into_std().unwrap().into()),
+            };
+            match fd {
+                Err(err) => log::warn!("Failed to allocate socket: {err}"),
+                Ok(fd) => owned_fd_buf.push(fd),
+            };
+        }
+
+        socket.writable().await?;
+
+        let raw_fd_buf: Vec<RawFd> = owned_fd_buf.iter().map(|fd| fd.as_raw_fd()).collect();
+        let cmsg = ControlMessage::ScmRights(&raw_fd_buf[..]);
+        let iov = [IoSlice::new(&buf[..])];
+
+        sendmsg::<()>(socket.as_raw_fd(), &iov, &[cmsg], MsgFlags::empty(), None)?;
+    }
+}

--- a/src/socks.rs
+++ b/src/socks.rs
@@ -354,10 +354,6 @@ impl ProxyHandlerManager for SocksProxyManager {
             command,
         )?)))
     }
-
-    fn get_server_addr(&self) -> SocketAddr {
-        self.server
-    }
 }
 
 impl SocksProxyManager {

--- a/src/socks.rs
+++ b/src/socks.rs
@@ -20,6 +20,7 @@ enum SocksState {
 }
 
 struct SocksProxyImpl {
+    server_addr: SocketAddr,
     info: SessionInfo,
     domain_name: Option<String>,
     state: SocksState,
@@ -35,6 +36,7 @@ struct SocksProxyImpl {
 
 impl SocksProxyImpl {
     fn new(
+        server_addr: SocketAddr,
         info: SessionInfo,
         domain_name: Option<String>,
         credentials: Option<UserKey>,
@@ -42,6 +44,7 @@ impl SocksProxyImpl {
         command: protocol::Command,
     ) -> Result<Self> {
         let mut result = Self {
+            server_addr,
             info,
             domain_name,
             state: SocksState::ClientHello,
@@ -260,6 +263,10 @@ impl SocksProxyImpl {
 
 #[async_trait::async_trait]
 impl ProxyHandler for SocksProxyImpl {
+    fn get_server_addr(&self) -> SocketAddr {
+        self.server_addr
+    }
+
     fn get_session_info(&self) -> SessionInfo {
         self.info
     }
@@ -339,6 +346,7 @@ impl ProxyHandlerManager for SocksProxyManager {
         let command = if udp_associate { UdpAssociate } else { Connect };
         let credentials = self.credentials.clone();
         Ok(Arc::new(Mutex::new(SocksProxyImpl::new(
+            self.server,
             info,
             domain_name,
             credentials,


### PR DESCRIPTION
## Motivation

Hi. I was trying to came up with some solution to make a network environment isolated from a global system setup with all traffic reaching outside routing via the a socks proxy or vpn instance in unprivileged (rootless) manner.

Usually this would require using something like veth pairs (virtual network interfaces) to bridge namespaces. But required modifications affect the global network namespace therefore require root-like capabilities. That aren't normally available to the user processes.

This why I came up with a solution utilizing TUN interface. And since it similar to what this project does, I decided to integrate that functionality here.

Here are use-cases I wanted to add support for:
- Create an isolated and proxified environment for applications that don't understand proxies by themselves.
- Separate vpn instances from global network namespace.
- Support flatpak application (this is tricky because some containerization solutions are messing up capabilities such that flatpak fails to run).
- Do everything above without requiring root-like capabilities.

## Implemented features
- Unprivileged mode which creates an isolated network environment (from the global network configuration) and bridges all the traffic reaching outside of it through the proxy. See `--unshare`.
- No-proxy mode which sends routes traffic directly to the requested address. See `--proxy none`.

## Usage
Create a new network namespace where all traffic reaching outside is routed through the socks5 proxy.

```sh
$ tun2proxy --unshare --startup --proxy "socks5://..."
...
```

Create a new network namespace without additional redirection of traffic with `openvpn` running in it (with root-like capabilities provided to allow network configuration).

```sh
$ tun2proxy --unshare --startup --proxy "none" -- openvpn [...]
...
```

Start `/bin/sh` in the namespace created by the `tun2proxy` started the latest. Persistent command is suggested in `tun2proxy` output.

```sh
$ nsenter --target $(pgrep -n tun2proxy) --preserve-credentials --user  --net --mount /bin/sh
```

## Architecture

There are three core ideas in play:
- When a process creates namespace it gains root-like capabilities. I.e. the ability to modify filesystem and network devices it the namespaces. This capability can be passed to descendant processes allowing them to create a TUN devices in unprivileged environment.
- A pair of interconnected `unix(7)` sockets may not only exchange data but also copies of valid file descriptors.
This mechanism is useful to transfer sockets bonded to the global network to another network namespace.
- File descriptors without `CLOEXEC` flag (it is usually set by the std implementation) are inherited in descending processes.

Using those ideas execution flow can be described as follows:
- First `tun2proxy` process with argument `--unshare` generates a pair of interconnected unix sockets unsetting `CLOEXEC` flag on one of those and converting it to raw file descriptor value.
- Then it starts `unshare(1)` process that creates a new namespace.
- `unshare` process is instructed to start `tun2proxy` binary again but this time with `--socket-transfer-fd <fd>` argument where `<fd>` is the raw file descriptor discussed earlier.
- `tun2proxy` process inside the new namespace initializes TUN interface and routing table as normal.
- But since network namespace it is running in is isolated, it can't connect to the proxy server directly. This what unix sockets are required for.
- After initialization is done, it starts transferring network sockets from the first `tun2proxy` process that is still in the global network namespace and sockets created by which are bonded to the global namespace even after the transfer to the descendant process occurs.
- The network admin process (see `[admin command]` cli argument) is started after the network is ready, preserving root-like capabilities, that process could be for example a vpn daemon.
- Then `tun2proxy` operates as usual.

## Code changes

- `bin/main.rs` - added a startup routine triggered if `--unshare` is specified.
- `args.rs` - added new cli arguments: `--proxy none`, `--unshare`, `--socket-transfer-fd <fd>`, `[admin\_command...]`, `udp_timeout`.
- `desktop_api.rs` - added code to spawn an `admin_command` and fix to allow running other proxy in a new namespace. 
- `lib.rs` - added functionality to fetch network sockets in case `--socket-tranfer-fd` was specified. Also a small fix to bunch series of `Mutex::lock` into one call where applicable.
- `no_proxy.rs` (created) - implementation of no-proxy mode, basically a no-op since it signals that connection is always established.
- `proxy_handle.rs` (and implementations of proxy protocols) - add `get_server_addr` function to `ProxyHandler` trait, previously server address was supplied directly from cli arguments.
- `socket_transfer.rs` (created) - functionality to safely transfer raw sockets between processes.

## Notes

- `tproxy-config` is lacking the support not to set ipv6 routing. This confuses some user application if proxy doesn't support ipv6 connectivity, e.g. causes timeout in resolution and subsequent fail of dns requests (this also could be attributed to `ipstack` not reporting unreachable destinations).

- `tproxy-config` is always setting *more specific* (compared to `0.0.0.0/0`) routing addresses even if no default route is presented in the network namespace. This causes mutual exclusion in routing tables for `0.0.0.0/1` and `128.0.0.0/1` address spaces with other proxy application (notably `openvpn`).
